### PR TITLE
Update o-ft-icons and switch to SVG icons

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
 	],
 	"dependencies": {
 		"o-colors": ">=2.5.0 <4",
-		"o-ft-icons": "^2.0.0",
+		"o-ft-icons": ">=3.2.0 <5",
 		"ftscroller": "https://github.com/ftlabs/ftscroller.git#^0.6.0",
 		"o-dom": ">=0.3.0 <2.0.0",
 		"ftdomdelegate": "^2.0.0",

--- a/src/scss/controls.scss
+++ b/src/scss/controls.scss
@@ -5,17 +5,14 @@
 
 /// Mixin to be applied to the gallery controls
 @mixin oGalleryControl {
-	@include oFtIconsBaseIconStyles();
 	@include oGalleryOverlayBackground();
 	position: absolute;
 	top: 50%;
 	margin-top: ($_o-gallery-control-height / 2) * -1;
 	width: $_o-gallery-control-width;
 	height: $_o-gallery-control-height;
-	font-size: 60px;
-	line-height: $_o-gallery-control-height;
-	text-align: center;
-	color: oColorsGetColorFor(o-gallery-overlay, text);
+	background-repeat: no-repeat;
+	background-position: 50% 50%;
 	overflow: hidden;
 	cursor: pointer;
 	@at-root #{$o-hoverable-if-hover-enabled} &:hover {
@@ -28,12 +25,20 @@
 	}
 
 	&--prev {
-		@extend %o-ft-icons-icon--arrow-left;
+		@include oFtIconsGetSvg('arrow-left', oColorsGetColorFor(o-gallery-overlay, text), $_o-gallery-control-width, $apply-base-styles: false);
 		left: 0;
+
+		&:hover {
+			@include oFtIconsGetSvg('arrow-left', oColorsGetColorFor(o-gallery-overlay-hover, text), $_o-gallery-control-width, $apply-base-styles: false);
+		}
 	}
 
 	&--next {
-		@extend %o-ft-icons-icon--arrow-right;
+		@include oFtIconsGetSvg('arrow-right', oColorsGetColorFor(o-gallery-overlay, text), $_o-gallery-control-width, $apply-base-styles: false);
 		right: 0;
+
+		&:hover {
+			@include oFtIconsGetSvg('arrow-right', oColorsGetColorFor(o-gallery-overlay-hover, text), $_o-gallery-control-width, $apply-base-styles: false);
+		}
 	}
 }

--- a/src/scss/controls.scss
+++ b/src/scss/controls.scss
@@ -15,11 +15,9 @@
 	background-position: 50% 50%;
 	overflow: hidden;
 	cursor: pointer;
-	@at-root #{$o-hoverable-if-hover-enabled} &:hover {
-		color: oColorsGetColorFor(o-gallery-overlay-hover, text);
-	}
 	visibility: hidden;
 	z-index: 5;
+
 	&[aria-hidden='false'] {
 		visibility: visible;
 	}
@@ -28,7 +26,7 @@
 		@include oFtIconsGetSvg('arrow-left', oColorsGetColorFor(o-gallery-overlay, text), $_o-gallery-control-width, $apply-base-styles: false);
 		left: 0;
 
-		&:hover {
+		@at-root #{$o-hoverable-if-hover-enabled} &:hover {
 			@include oFtIconsGetSvg('arrow-left', oColorsGetColorFor(o-gallery-overlay-hover, text), $_o-gallery-control-width, $apply-base-styles: false);
 		}
 	}
@@ -37,7 +35,7 @@
 		@include oFtIconsGetSvg('arrow-right', oColorsGetColorFor(o-gallery-overlay, text), $_o-gallery-control-width, $apply-base-styles: false);
 		right: 0;
 
-		&:hover {
+		@at-root #{$o-hoverable-if-hover-enabled} &:hover {
 			@include oFtIconsGetSvg('arrow-right', oColorsGetColorFor(o-gallery-overlay-hover, text), $_o-gallery-control-width, $apply-base-styles: false);
 		}
 	}

--- a/src/scss/controls.scss
+++ b/src/scss/controls.scss
@@ -26,7 +26,7 @@
 		@include oFtIconsGetSvg('arrow-left', oColorsGetColorFor(o-gallery-overlay, text), $_o-gallery-control-width, $apply-base-styles: false);
 		left: 0;
 
-		@at-root #{$o-hoverable-if-hover-enabled} &:hover {
+		#{$o-hoverable-if-hover-enabled} &:hover {
 			@include oFtIconsGetSvg('arrow-left', oColorsGetColorFor(o-gallery-overlay-hover, text), $_o-gallery-control-width, $apply-base-styles: false);
 		}
 	}
@@ -35,7 +35,7 @@
 		@include oFtIconsGetSvg('arrow-right', oColorsGetColorFor(o-gallery-overlay, text), $_o-gallery-control-width, $apply-base-styles: false);
 		right: 0;
 
-		@at-root #{$o-hoverable-if-hover-enabled} &:hover {
+		#{$o-hoverable-if-hover-enabled} &:hover {
 			@include oFtIconsGetSvg('arrow-right', oColorsGetColorFor(o-gallery-overlay-hover, text), $_o-gallery-control-width, $apply-base-styles: false);
 		}
 	}


### PR DESCRIPTION
Updates the `o-ft-icons` dependency to use `>3.2` which has the SVG mixin.

Update the controls to use the SVG mixin.