### PR TITLE
Remove o-hoverable with "@media (hover)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,10 +275,6 @@ In addition to this, a `aria-selected="true"` attribute is set on the _selected_
 
 Themes must only be used with the default `o-gallery` classes.
 
-### Hover styles
-
-Gallery uses `:hover` styles. These can be enabled by products adding the `o-hoverable-on` class to the document body.
-
 ## Migration Guide
 
 ### Migrating from v2.x.x -> v3.x.x

--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,6 @@
     "ftscroller": "https://github.com/ftlabs/ftscroller.git#^0.6.0",
     "ftdomdelegate": "^2.0.0",
     "o-viewport": ">=0.1.1 <4.0.0",
-    "o-hoverable": ">=0.1.1 <4",
     "o-icons": "^4.1.0 <6"
   }
 }

--- a/main.scss
+++ b/main.scss
@@ -1,7 +1,6 @@
 @import "o-assets/main";
 @import "o-colors/main";
 @import "o-icons/main";
-@import "o-hoverable/main";
 
 @import "src/scss/color-use-cases";
 @import "src/scss/variables";

--- a/src/scss/controls.scss
+++ b/src/scss/controls.scss
@@ -32,9 +32,16 @@
 			content: '';
 		}
 
-		&:focus,
-		#{$o-hoverable-if-hover-enabled} &:hover {
+		&:focus {
 			@include oIconsGetIcon('arrow-left', oColorsGetColorFor(o-gallery-overlay-hover, text), $_o-gallery-control-width, $apply-base-styles: false, $iconset-version: 1);
+		}
+
+		// Only show the hover state if the primary device input supports hover.
+		// i.e. don't change the button on tap.
+		@media (hover) {
+			&:hover {
+				@include oIconsGetIcon('arrow-left', oColorsGetColorFor(o-gallery-overlay-hover, text), $_o-gallery-control-width, $apply-base-styles: false, $iconset-version: 1);
+			}
 		}
 	}
 
@@ -48,9 +55,16 @@
 			content: '';
 		}
 
-		&:focus,
-		#{$o-hoverable-if-hover-enabled} &:hover {
+		&:focus {
 			@include oIconsGetIcon('arrow-right', oColorsGetColorFor(o-gallery-overlay-hover, text), $_o-gallery-control-width, $apply-base-styles: false, $iconset-version: 1);
+		}
+
+		// Only show the hover state if the primary device input supports hover.
+		// i.e. don't change the button on tap.
+		@media (hover) {
+			&:hover {
+				@include oIconsGetIcon('arrow-right', oColorsGetColorFor(o-gallery-overlay-hover, text), $_o-gallery-control-width, $apply-base-styles: false, $iconset-version: 1);
+			}
 		}
 	}
 }

--- a/src/scss/controls.scss
+++ b/src/scss/controls.scss
@@ -32,15 +32,16 @@
 			content: '';
 		}
 
+		&:hover,
 		&:focus {
 			@include oIconsGetIcon('arrow-left', oColorsGetColorFor(o-gallery-overlay-hover, text), $_o-gallery-control-width, $apply-base-styles: false, $iconset-version: 1);
 		}
 
-		// Only show the hover state if the primary device input supports hover.
-		// i.e. don't change the button on tap.
-		@media (hover) {
+		// Reset the hover state for primarily touch based devices, so hover has no visual effect.
+		// IE11 does not support `@media (hover)`, which is why the hover state is applied by default.
+		@media (hover: none) {
 			&:hover {
-				@include oIconsGetIcon('arrow-left', oColorsGetColorFor(o-gallery-overlay-hover, text), $_o-gallery-control-width, $apply-base-styles: false, $iconset-version: 1);
+				@include oIconsGetIcon('arrow-left', oColorsGetColorFor(o-gallery-overlay, text), $_o-gallery-control-width, $apply-base-styles: false, $iconset-version: 1);
 			}
 		}
 	}
@@ -55,15 +56,16 @@
 			content: '';
 		}
 
+		&:hover,
 		&:focus {
 			@include oIconsGetIcon('arrow-right', oColorsGetColorFor(o-gallery-overlay-hover, text), $_o-gallery-control-width, $apply-base-styles: false, $iconset-version: 1);
 		}
 
-		// Only show the hover state if the primary device input supports hover.
-		// i.e. don't change the button on tap.
-		@media (hover) {
+		// Reset the hover state for primarily touch based devices, so hover has no visual effect.
+		// IE11 does not support `@media (hover)`, which is why the hover state is applied by default.
+		@media (hover: none) {
 			&:hover {
-				@include oIconsGetIcon('arrow-right', oColorsGetColorFor(o-gallery-overlay-hover, text), $_o-gallery-control-width, $apply-base-styles: false, $iconset-version: 1);
+				@include oIconsGetIcon('arrow-right', oColorsGetColorFor(o-gallery-overlay, text), $_o-gallery-control-width, $apply-base-styles: false, $iconset-version: 1);
 			}
 		}
 	}


### PR DESCRIPTION
Swaps `o-hoverable`  for the native [hover media query](https://drafts.csswg.org/mediaqueries-4/#hover). Removing so we can deprecate o-hoverable: https://github.com/Financial-Times/o-hoverable/issues/29