### PR TITLE
Allow version 2 or 3 of ftdomdelegate.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "o-colors": "^4.0.0",
     "ftscroller": "https://github.com/ftlabs/ftscroller.git#^0.6.0",
-    "ftdomdelegate": "^2.0.0",
+    "ftdomdelegate": ">=2.2.0 <4.0.0",
     "o-viewport": ">=0.1.1 <4.0.0",
     "o-icons": "^4.1.0 <6"
   }


### PR DESCRIPTION
v3 of ftdomdelegate has the same api as v2. It was named
dom-delegate in its manifest files and v3 makes the name
consistent. It was also released (renamed) as 2.2.0 on npm.

https://github.com/Financial-Times/ftdomdelegate/pull/93